### PR TITLE
Fka3/anonid

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,21 +51,27 @@ FullStory.prototype.loaded = function() {
 };
 
 /**
- * Identify.
+ * Identify.  But, use FS.setUserVars if we only have an anonymous id, keeping the
+ * user id unbound until we (hopefully) get a login page or similar and another call
+ * to identify with more useful contents.  (This because FullStory doesn't like the
+ * user id changing once set.)
  *
  * @param {Identify} identify
  */
 
 FullStory.prototype.identify = function(identify) {
-  var id = identify.userId() || identify.anonymousId();
   var traits = identify.traits({ name: 'displayName' });
 
   var newTraits = foldl(function(results, value, key) {
     if (key !== 'id') results[key === 'displayName' || key === 'email' ? key : convert(key, value)] = value;
     return results;
   }, {}, traits);
-
-  window.FS.identify(String(id), newTraits);
+  if (identify.userId()) {
+    window.FS.identify(String(identify.userId()), newTraits);
+  } else {
+    newTraits.Analytics_AnonymousId_str = String(identify.anonymousId());
+    window.FS.setUserVars(newTraits);
+  }
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,7 @@ FullStory.prototype.identify = function(identify) {
   if (identify.userId()) {
     window.FS.identify(String(identify.userId()), newTraits);
   } else {
-    newTraits.Analytics_AnonymousId_str = String(identify.anonymousId());
+    newTraits.segmentAnonymousId_str = String(identify.anonymousId());
     window.FS.setUserVars(newTraits);
   }
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -68,7 +68,7 @@ describe('FullStory', function() {
 
       it('should default to anonymousId', function() {
         analytics.identify();
-        analytics.called(window.FS.identify);
+        analytics.called(window.FS.setUserVars);
       });
 
       it('should only send strings as the id', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -64,6 +64,7 @@ describe('FullStory', function() {
     describe('#identify', function() {
       beforeEach(function() {
         analytics.stub(window.FS, 'identify');
+        analytics.stub(window.FS, 'setUserVars');
       });
 
       it('should default to anonymousId', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -73,7 +73,7 @@ describe('FullStory', function() {
         analytics.called(window.FS.setUserVars);
         var traits = window.FS.setUserVars.args[0][0];
         analytics.assert(traits && traits.hasOwnProperty('segmentAnonymousId_str'),
-           "didn't set anonymous id correctly");
+           'did not set anonymous id correctly');
       });
 
       it('should only send strings as the id', function() {
@@ -82,7 +82,7 @@ describe('FullStory', function() {
         analytics.didNotCall(window.FS.setUserVars);
         var traits = window.FS.identify.args[0][0];
         analytics.assert(traits && !traits.hasOwnProperty('segmentAnonymousId_str'),
-           "did set anonymous id despite user id");
+           'did set anonymous id despite user id');
       });
 
       it('should send an id', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -69,12 +69,20 @@ describe('FullStory', function() {
 
       it('should default to anonymousId', function() {
         analytics.identify();
+        analytics.didNotCall(window.FS.identify);
         analytics.called(window.FS.setUserVars);
+        var traits = window.FS.setUserVars.args[0][0];
+        analytics.assert(traits && traits.hasOwnProperty('segmentAnonymousId_str'),
+           "didn't set anonymous id correctly");
       });
 
       it('should only send strings as the id', function() {
         analytics.identify(1);
         analytics.called(window.FS.identify, '1');
+        analytics.didNotCall(window.FS.setUserVars);
+        var traits = window.FS.identify.args[0][0];
+        analytics.assert(traits && !traits.hasOwnProperty('segmentAnonymousId_str'),
+           "did set anonymous id despite user id");
       });
 
       it('should send an id', function() {


### PR DESCRIPTION
I'd discussed the issue this is aiming to fix with Brantley Beaird; we have users calling first analytics.identify() from their login page and then, after login, analytics.identify({...useful stuff...}).  But, because the first call pins the user id to the anonymous UUID, the second, useful call is rejected because it seems to be trying to change the (immutable) user id.

Please have a look, and let me know what you think!