### PR TITLE
When users pass compound objects (arrays or non-Date objects), don't …

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -88,6 +88,7 @@ function convert(key, value) {
   if (isFloat(value)) return key + '_real';
   if (is.date(value)) return key + '_date';
   if (is.boolean(value)) return key + '_bool';
+  return key;  // Bad FullStory type, but don't mess with the key so error messages name it
 }
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -119,6 +119,16 @@ describe('FullStory', function() {
         analytics.identify('id3', { name: 'Steven', registered: true });
         analytics.called(window.FS.identify, 'id3', { displayName: 'Steven', registered_bool: true });
       });
+
+      it('should pass arrays through un-tagged', function() {
+        analytics.identify('id3', { teams: ['eng', 'redsox'] });
+        analytics.called(window.FS.identify, 'id3', { teams: [ 'eng', 'redsox'] });
+      });
+
+      it('should pass user objects through un-tagged', function() {
+        analytics.identify('id3', { account: { level: 'premier', avg_annual: 30000 } });
+        analytics.called(window.FS.identify, 'id3', { account: { level: 'premier', avg_annual: 30000 } });
+      });
     });
   });
 });


### PR DESCRIPTION
…mess with

the key key name.  Existing behavior makes the key become "undefined," which
isn't what the user wants, causes collisions if there's more than one, and isn't
a valid name to FullStory anyway.

Even with this change, FullStory isn't going to *accept* the compound value,
because it doesn't support objects or arrays, but this way it can whine about
the correct name and the user can understand what is going on.