### PR TITLE
Update FullStory snippet: fix shutdown/restart functions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,12 +32,12 @@ FullStory.prototype.initialize = function() {
 
   /* eslint-disable */
   (function(m,n,e,t,l,o,g,y){
+    if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].');} return;}
     g=m[e]=function(a,b){g.q?g.q.push([a,b]):g._api(a,b);};g.q=[];
     g.identify=function(i,v){g(l,{uid:i});if(v)g(l,v)};g.setUserVars=function(v){g(l,v)};
+    y="rec";g.shutdown=function(i,v){g(y,!1)};g.restart=function(i,v){g(y,!0)};
     g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
-    g.clearUserCookie=function(c,d,i){if(!c || document.cookie.match('fs_uid=[`;`]*`[`;`]*`[`;`]*`')){
-    d=n.domain;while(1){n.cookie='fs_uid=;domain='+d+
-    ';path=/;expires='+new Date(0).toUTCString();i=d.indexOf('.');if(i<0)break;d=d.slice(i+1)}}};
+    g.clearUserCookie=function(){};
   })(window,document,window['_fs_namespace'],'script','user');
   /* eslint-enable */
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,8 +35,8 @@ FullStory.prototype.initialize = function() {
     if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].');} return;}
     g=m[e]=function(a,b){g.q?g.q.push([a,b]):g._api(a,b);};g.q=[];
     g.identify=function(i,v){g(l,{uid:i});if(v)g(l,v)};g.setUserVars=function(v){g(l,v)};
-    y="rec";g.shutdown=function(i,v){g(y,!1)};g.restart=function(i,v){g(y,!0)};
-    y="consent";g[y]=function(a){g(y,!arguments.length||a)};
+    g.shutdown=function(){g("rec",!1)};g.restart=function(){g("rec",!0)};
+    g.consent=function(a){g("consent",!arguments.length||a)};
     g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
     g.clearUserCookie=function(){};
   })(window,document,window['_fs_namespace'],'script','user');


### PR DESCRIPTION
The FullStory bootstrap snippet in the existing integration contains a flaw in the way that the `startup`, `shutdown`, and `consent` API calls are initialized, such that `startup` and `shutdown` don't work.  This is a small change to fix those calls.

Upgrade of the snippet requires no action on the part of our mutual customers, and this version has already been deployed to FullStory's production servers.